### PR TITLE
Testing Mutliple JDKs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ os: linux
 
 jdk:
   - openjdk8
-  - oraclejdk8
   - openjdk9
-  - oraclejdk9
   - openjdk10
-  - oraclejdk10
   - openjdk11
-  - oraclejdk11
+  - openjdk-ea
+
+matrix:
+  allow_failures:
+    - jdk: openjdk-ea
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
+language: java
+
 os: linux
 
-language: java
 jdk:
   - openjdk8
+  - openjdk9
   - openjdk10
   - openjdk11
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,13 @@ os: linux
 
 jdk:
   - openjdk8
+  - oraclejdk8
   - openjdk9
+  - oraclejdk9
   - openjdk10
+  - oraclejdk10
   - openjdk11
+  - oraclejdk11
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ os: linux
 language: java
 jdk:
   - openjdk8
+  - openjdk10
+  - openjdk11
 
 cache:
   directories:


### PR DESCRIPTION
The following JDKs are added to the CI/CD:

- OpenJDK8
- OpenJDK9
- OpenJDK10
- OpenJDK11
- OpenJDK EA (pre-release)

The EA is allowed to fail.

Resolves #15 