### PR TITLE
:sparkles: Max order method added to API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ check.dependsOn jacocoTestCoverageVerification
 jacocoTestCoverageVerification.dependsOn jacocoTestReport
 
 group = 'za.ac.sun.grapl'
-version = '0.0.1'
+version = '0.0.2'
 description = 'GraPLHook4j'
 sourceCompatibility = '8'
 

--- a/src/main/java/za/ac/sun/grapl/hooks/IHook.java
+++ b/src/main/java/za/ac/sun/grapl/hooks/IHook.java
@@ -107,4 +107,11 @@ public interface IHook {
      */
     void assignToBlock(MethodVertex rootMethod, ControlStructureVertex control, int blockOrder);
 
+    /**
+     * Traverses the AST nodes to search for the largest order value.
+     *
+     * @return the largest order property.
+     */
+    int maxOrder();
+
 }

--- a/src/main/java/za/ac/sun/grapl/hooks/TinkerGraphHook.java
+++ b/src/main/java/za/ac/sun/grapl/hooks/TinkerGraphHook.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.UUID;
 
+import static org.apache.tinkerpop.gremlin.process.traversal.Order.desc;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.inV;
 
 public class TinkerGraphHook implements IHook {
@@ -172,6 +173,15 @@ public class TinkerGraphHook implements IHook {
     @Override
     public void assignToBlock(MethodVertex rootMethod, ControlStructureVertex control, int blockOrder) {
         createTinkerGraphEdge(findBlock(rootMethod, blockOrder), EdgeLabels.AST, createTinkerGraphVertex(control));
+    }
+
+    @Override
+    public int maxOrder() {
+        final GraphTraversalSource g = graph.traversal();
+        if (g.V().has("order").hasNext())
+            return Integer.parseInt(g.V().order().by("order", desc).limit(1).values("order").next().toString());
+        else
+            return 0;
     }
 
     /**

--- a/src/test/java/za/ac/sun/grapl/hooks/TinkerGraphHookTest.java
+++ b/src/test/java/za/ac/sun/grapl/hooks/TinkerGraphHookTest.java
@@ -455,4 +455,42 @@ public class TinkerGraphHookTest {
                     .out(EdgeLabels.AST.toString()).count().next());
         }
     }
+
+    @Nested
+    @DisplayName("TinkerGraph: Aggregate queries")
+    class TinkerGraphAggregateQueries {
+
+        private TinkerGraphHook hook;
+        private TinkerGraph testGraph;
+
+        @BeforeEach
+        public void setUp() {
+            this.hook = new TinkerGraphHookBuilder(testGraphML).createNewGraph(true).build();
+            this.testGraph = TinkerGraph.open();
+        }
+
+        @Test
+        public void testEmptyGraph() {
+            assertEquals(0, this.hook.maxOrder());
+        }
+
+        @Test
+        public void testNonEmptyGraphWithASTVertices() {
+            FileVertex f = new FileVertex("Test", 0);
+            MethodVertex m = new MethodVertex("root", "io.grapl.Test.run", "(I)", 0, 0);
+            this.hook.joinFileVertexTo(f, m);
+            this.hook.assignToBlock(m, new BlockVertex("firstBlock", 1, 1, "INTEGER", 5), 0);
+            this.hook.assignToBlock(m, new BlockVertex("secondBlock", 2, 1, "INTEGER", 6), 0);
+            assertEquals(2, this.hook.maxOrder());
+        }
+
+        @Test
+        public void testNonEmptyGraphWithoutASTVertices() {
+            testGraph.addVertex("EmptyVertex");
+            testGraph.traversal().io(testGraphML).write().iterate();
+            this.hook = new TinkerGraphHookBuilder(testGraphML).createNewGraph(false).build();
+
+            assertEquals(0, this.hook.maxOrder());
+        }
+    }
 }


### PR DESCRIPTION
- hook.maxOrder() method introduced
- The max value of the AST order of a graph can now be obtained

Resolves #18 