### PR TITLE
:ambulance: Made properties native types instead of all string

### DIFF
--- a/src/main/java/za/ac/sun/grapl/domain/mappers/VertexMapper.kt
+++ b/src/main/java/za/ac/sun/grapl/domain/mappers/VertexMapper.kt
@@ -13,7 +13,8 @@ class VertexMapper {
             properties["label"] = objectVertex.javaClass.getDeclaredField("LABEL").get(objectVertex).toString()
             objectVertex::class.memberProperties.forEach {
                 if (it.visibility == KVisibility.PUBLIC) {
-                    properties[it.name] = it.getter.call(objectVertex)!!
+                    if (it.getter.call(objectVertex) is Enum<*>) properties[it.name] = it.getter.call(objectVertex).toString()
+                    else properties[it.name] = it.getter.call(objectVertex)!!
                 }
             }
             return properties

--- a/src/main/java/za/ac/sun/grapl/domain/mappers/VertexMapper.kt
+++ b/src/main/java/za/ac/sun/grapl/domain/mappers/VertexMapper.kt
@@ -8,12 +8,12 @@ class VertexMapper {
 
     companion object {
         @JvmStatic
-        fun propertiesToMap(objectVertex: GraPLVertex): MutableMap<String, String> {
-            val properties = emptyMap<String, String>().toMutableMap()
+        fun propertiesToMap(objectVertex: GraPLVertex): MutableMap<String, Any> {
+            val properties = emptyMap<String, Any>().toMutableMap()
             properties["label"] = objectVertex.javaClass.getDeclaredField("LABEL").get(objectVertex).toString()
             objectVertex::class.memberProperties.forEach {
                 if (it.visibility == KVisibility.PUBLIC) {
-                    properties[it.name] = it.getter.call(objectVertex).toString()
+                    properties[it.name] = it.getter.call(objectVertex)!!
                 }
             }
             return properties

--- a/src/main/java/za/ac/sun/grapl/hooks/GremlinHook.java
+++ b/src/main/java/za/ac/sun/grapl/hooks/GremlinHook.java
@@ -76,7 +76,7 @@ public abstract class GremlinHook implements IHook {
      */
     private Vertex findVertex(final FileVertex from) {
         return g.V().has(FileVertex.LABEL.toString(), "name", from.getName())
-                .has("order", String.valueOf(from.getOrder())).next();
+                .has("order", from.getOrder()).next();
     }
 
     /**
@@ -108,7 +108,7 @@ public abstract class GremlinHook implements IHook {
      */
     private boolean vertexNotPresent(final FileVertex v) {
         return !g.V().has(FileVertex.LABEL.toString(), "name", v.getName())
-                .has("order", String.valueOf(v.getOrder())).hasNext();
+                .has("order", v.getOrder()).hasNext();
     }
 
     @Override
@@ -246,7 +246,7 @@ public abstract class GremlinHook implements IHook {
         startTransaction();
         int result = 0;
         if (g.V().has("order").hasNext())
-            result = Integer.parseInt(g.V().order().by("order", desc).limit(1).values("order").next().toString());
+            result = (int) g.V().order().by("order", desc).limit(1).values("order").next();
         endTransaction();
         return result;
     }
@@ -254,7 +254,7 @@ public abstract class GremlinHook implements IHook {
     @Override
     public boolean isASTVertex(final int blockOrder) {
         startTransaction();
-        boolean result = g.V().has("order", String.valueOf(blockOrder)).hasNext();
+        boolean result = g.V().has("order", blockOrder).hasNext();
         endTransaction();
         return result;
     }
@@ -292,7 +292,7 @@ public abstract class GremlinHook implements IHook {
     private Vertex findASTVertex(final MethodVertex root, final int blockOrder) {
         if (root.getOrder() == blockOrder) return g.V(findVertex(root)).next();
         return g.V(findVertex(root)).repeat(__.out("AST")).emit()
-                .has("order", String.valueOf(blockOrder)).next();
+                .has("order", blockOrder).next();
     }
 
     /**
@@ -303,7 +303,7 @@ public abstract class GremlinHook implements IHook {
      * @return the {@link Vertex} associated with the AST block.
      */
     private Vertex findASTVertex(final int order) {
-        return g.V().has("order", String.valueOf(order)).next();
+        return g.V().has("order", order).next();
     }
 
     /**
@@ -314,9 +314,9 @@ public abstract class GremlinHook implements IHook {
      * @return the newly created {@link Vertex}.
      */
     private Vertex createTinkerGraphVertex(final GraPLVertex gv) {
-        final Map<String, String> propertyMap = VertexMapper.propertiesToMap(gv);
+        final Map<String, Object> propertyMap = VertexMapper.propertiesToMap(gv);
         // Get the implementing class label parameter
-        final String label = propertyMap.remove("label");
+        final String label = (String) propertyMap.remove("label");
         // Get the implementing classes fields and values
         Vertex v;
         if (this instanceof TinkerGraphHook) {
@@ -324,7 +324,7 @@ public abstract class GremlinHook implements IHook {
             propertyMap.forEach(v::property);
         } else {
             GraphTraversal<Vertex, Vertex> traversalPointer = g.addV(label);
-            for (Map.Entry<String, String> f : propertyMap.entrySet()) {
+            for (Map.Entry<String, Object> f : propertyMap.entrySet()) {
                 traversalPointer = traversalPointer.property(f.getKey(), f.getValue());
             }
             v = traversalPointer.next();

--- a/src/test/java/za/ac/sun/grapl/hooks/GremlinHookTest.java
+++ b/src/test/java/za/ac/sun/grapl/hooks/GremlinHookTest.java
@@ -117,7 +117,7 @@ abstract public class GremlinHookTest {
             assertTrue(this.hook.g.E().hasLabel(EdgeLabels.AST.toString()).hasNext());
             assertTrue(this.hook.g.V().hasLabel(MethodVertex.LABEL.toString())
                     .out(EdgeLabels.AST.toString())
-                    .has(ModifierVertex.LABEL.toString(), "name", ModifierTypes.PUBLIC)
+                    .has(ModifierVertex.LABEL.toString(), "name", ModifierTypes.PUBLIC.toString())
                     .hasNext());
             this.hook.endTransaction();
         }

--- a/src/test/java/za/ac/sun/grapl/hooks/GremlinHookTest.java
+++ b/src/test/java/za/ac/sun/grapl/hooks/GremlinHookTest.java
@@ -4,12 +4,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.*;
 import za.ac.sun.grapl.domain.enums.*;
-import za.ac.sun.grapl.domain.models.GraPLVertex;
 import za.ac.sun.grapl.domain.models.vertices.*;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.EnumSet;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -119,7 +117,7 @@ abstract public class GremlinHookTest {
             assertTrue(this.hook.g.E().hasLabel(EdgeLabels.AST.toString()).hasNext());
             assertTrue(this.hook.g.V().hasLabel(MethodVertex.LABEL.toString())
                     .out(EdgeLabels.AST.toString())
-                    .has(ModifierVertex.LABEL.toString(), "name", ModifierTypes.PUBLIC.toString())
+                    .has(ModifierVertex.LABEL.toString(), "name", ModifierTypes.PUBLIC)
                     .hasNext());
             this.hook.endTransaction();
         }


### PR DESCRIPTION
- All properties retain their original types
- Non-standard objects become stringified